### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,36 +127,39 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless @items.exists?%>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -172,6 +175,7 @@
             </div>
           </div>
         </div>
+        <% end %>
         <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
トップページに登録した商品の情報を展開するため

# 添付資料
商品が存在する場合の挙動((非ログイン状態)
https://gyazo.com/fcae09c18fbf46a15600da22ec925cd9

商品を登録した際の挙動
https://gyazo.com/fea85bad7bc38dd16d2da4e058ed23f8

商品が存在しない場合の挙動
https://gyazo.com/b0476fe3ad177aa460ce08f1761fc330
